### PR TITLE
Fix : `vm_type.h` 분리 및 VM 관련 인클루드 의존성 해결, `process_impl.c` 수정

### DIFF
--- a/include/vm/uninit.h
+++ b/include/vm/uninit.h
@@ -1,5 +1,6 @@
 #ifndef VM_UNINIT_H
 #define VM_UNINIT_H
+#include "vm/vm_type.h"
 #include "vm/vm.h"
 
 struct page;

--- a/include/vm/uninit.h
+++ b/include/vm/uninit.h
@@ -1,7 +1,7 @@
 #ifndef VM_UNINIT_H
 #define VM_UNINIT_H
+#include <stdbool.h>
 #include "vm/vm_type.h"
-#include "vm/vm.h"
 
 struct page;
 enum vm_type;

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,8 +1,9 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
-#include "threads/palloc.h"
 #include "vm/vm_type.h"
+
+#include "threads/palloc.h"
 
 #include "vm/uninit.h"
 #include "vm/anon.h"

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,33 +1,12 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
-
 #include "threads/palloc.h"
+#include "vm/vm_type.h"
 
-enum vm_type {
-    /* page not initialized */
-    VM_UNINIT = 0,
-    /* page not related to the file, aka anonymous page */
-    VM_ANON = 1,
-    /* page that realated to the file */
-    VM_FILE = 2,
-    /* page that hold the page cache, for project 4 */
-    VM_PAGE_CACHE = 3,
-
-    /* Bit flags to store state */
-
-    /* Auxillary bit flag marker for store information. You can add more
-     * markers, until the value is fit in the int. */
-    VM_MARKER_0 = (1 << 3),
-    VM_MARKER_1 = (1 << 4),
-
-    /* DO NOT EXCEED THIS VALUE. */
-    VM_MARKER_END = (1 << 31),
-};
-
+#include "vm/uninit.h"
 #include "vm/anon.h"
 #include "vm/file.h"
-#include "vm/uninit.h"
 #ifdef EFILESYS
 #include "filesys/page_cache.h"
 #endif

--- a/include/vm/vm_type.h
+++ b/include/vm/vm_type.h
@@ -1,0 +1,25 @@
+#ifndef VM_TYPE_H
+#define VM_TYPE_H
+
+enum vm_type {
+    /* page not initialized */
+    VM_UNINIT = 0,
+    /* page not related to the file, aka anonymous page */
+    VM_ANON = 1,
+    /* page that realated to the file */
+    VM_FILE = 2,
+    /* page that hold the page cache, for project 4 */
+    VM_PAGE_CACHE = 3,
+
+    /* Bit flags to store state */
+
+    /* Auxillary bit flag marker for store information. You can add more
+     * markers, until the value is fit in the int. */
+    VM_MARKER_0 = (1 << 3),
+    VM_MARKER_1 = (1 << 4),
+
+    /* DO NOT EXCEED THIS VALUE. */
+    VM_MARKER_END = (1 << 31),
+};
+
+#endif 

--- a/userprog/.test_status
+++ b/userprog/.test_status
@@ -15,8 +15,8 @@ create-normal PASS
 priority-donate-lower PASS
 bad-write PASS
 open-twice PASS
-exec-arg PASS
 exec-missing PASS
+exec-arg PASS
 read-bad-ptr PASS
 dup2-complex PASS
 create-long PASS
@@ -25,8 +25,8 @@ fork-close PASS
 alarm-simultaneous PASS
 fork-boundary PASS
 priority-donate-chain PASS
-create-bound PASS
 rox-multichild PASS
+create-bound PASS
 lg-random PASS
 priority-condvar PASS
 priority-donate-nest PASS
@@ -42,15 +42,15 @@ sm-seq-block PASS
 multi-recurse PASS
 alarm-priority PASS
 close-twice PASS
-args-none PASS
+args-none FAIL
 create-bad-ptr PASS
 read-stdout PASS
 priority-fifo PASS
 wait-bad-pid PASS
 lg-create PASS
 exec-read PASS
-priority-sema PASS
 read-boundary PASS
+priority-sema PASS
 wait-twice PASS
 exec-boundary PASS
 close-normal PASS

--- a/userprog/process_impl.c
+++ b/userprog/process_impl.c
@@ -72,12 +72,16 @@ uint64_t *push_stack(char *arg, size_t size, struct intr_frame *if_) {
         page_bottom -= PGSIZE;
         uint8_t *kpage = palloc_get_page(PAL_USER | PAL_ZERO);
         if (kpage != NULL) {
+            #ifndef VM
             if (!install_page((void *)page_bottom, kpage, true)) {
                 palloc_free_page(kpage);
                 page_bottom += PGSIZE;
                 alloc_fail = true;
                 break;
             }
+            #else
+            //TODO : vm
+            #endif
         }
     }
 

--- a/vm/.test_config
+++ b/vm/.test_config
@@ -1,0 +1,163 @@
+# .test_config format:
+# test_name | pre_args | post_args | prog_args | test_path
+#
+# Fields:
+#   test_name : 테스트 식별용 이름
+#   pre_args  : 'pintos' 호출 시 -- 이전 옵션들
+#   post_args : 'pintos' 호출 시 -- 이후, run 이전 옵션들
+#   prog_args : 작은따옴표로 묶인 테스트 실행 인자 전체
+#   test_path : 테스트 바이너리 경로 (호스트 파일 시스템 내)
+
+[userprog]
+args-none | --fs-disk=10 -p tests/userprog/args-none:args-none --swap-disk=4 | -q   -f run | 'args-none' | tests/userprog
+args-single | --fs-disk=10 -p tests/userprog/args-single:args-single --swap-disk=4 | -q   -f run | 'args-single onearg' | tests/userprog
+args-multiple | --fs-disk=10 -p tests/userprog/args-multiple:args-multiple --swap-disk=4 | -q   -f run | 'args-multiple some arguments for you!' | tests/userprog
+args-many | --fs-disk=10 -p tests/userprog/args-many:args-many --swap-disk=4 | -q   -f run | 'args-many a b c d e f g h i j k l m n o p q r s t u v' | tests/userprog
+args-dbl-space | --fs-disk=10 -p tests/userprog/args-dbl-space:args-dbl-space --swap-disk=4 | -q   -f run | 'args-dbl-space two  spaces!' | tests/userprog
+halt | --fs-disk=10 -p tests/userprog/halt:halt --swap-disk=4 | -q   -f run | 'halt' | tests/userprog
+exit | --fs-disk=10 -p tests/userprog/exit:exit --swap-disk=4 | -q   -f run | 'exit' | tests/userprog
+create-normal | --fs-disk=10 -p tests/userprog/create-normal:create-normal --swap-disk=4 | -q   -f run | 'create-normal' | tests/userprog
+create-empty | --fs-disk=10 -p tests/userprog/create-empty:create-empty --swap-disk=4 | -q   -f run | 'create-empty' | tests/userprog
+create-null | --fs-disk=10 -p tests/userprog/create-null:create-null --swap-disk=4 | -q   -f run | 'create-null' | tests/userprog
+create-bad-ptr | --fs-disk=10 -p tests/userprog/create-bad-ptr:create-bad-ptr --swap-disk=4 | -q   -f run | 'create-bad-ptr' | tests/userprog
+create-long | --fs-disk=10 -p tests/userprog/create-long:create-long --swap-disk=4 | -q   -f run | 'create-long' | tests/userprog
+create-exists | --fs-disk=10 -p tests/userprog/create-exists:create-exists --swap-disk=4 | -q   -f run | 'create-exists' | tests/userprog
+create-bound | --fs-disk=10 -p tests/userprog/create-bound:create-bound --swap-disk=4 | -q   -f run | 'create-bound' | tests/userprog
+open-normal | --fs-disk=10 -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'open-normal' | tests/userprog
+open-missing | --fs-disk=10 -p tests/userprog/open-missing:open-missing --swap-disk=4 | -q   -f run | 'open-missing' | tests/userprog
+open-boundary | --fs-disk=10 -p tests/userprog/open-boundary:open-boundary -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'open-boundary' | tests/userprog
+open-empty | --fs-disk=10 -p tests/userprog/open-empty:open-empty --swap-disk=4 | -q   -f run | 'open-empty' | tests/userprog
+open-null | --fs-disk=10 -p tests/userprog/open-null:open-null --swap-disk=4 | -q   -f run | 'open-null' | tests/userprog
+open-bad-ptr | --fs-disk=10 -p tests/userprog/open-bad-ptr:open-bad-ptr --swap-disk=4 | -q   -f run | 'open-bad-ptr' | tests/userprog
+open-twice | --fs-disk=10 -p tests/userprog/open-twice:open-twice -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'open-twice' | tests/userprog
+close-normal | --fs-disk=10 -p tests/userprog/close-normal:close-normal -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'close-normal' | tests/userprog
+close-twice | --fs-disk=10 -p tests/userprog/close-twice:close-twice -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'close-twice' | tests/userprog
+close-bad-fd | --fs-disk=10 -p tests/userprog/close-bad-fd:close-bad-fd --swap-disk=4 | -q   -f run | 'close-bad-fd' | tests/userprog
+read-normal | --fs-disk=10 -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'read-normal' | tests/userprog
+read-bad-ptr | --fs-disk=10 -p tests/userprog/read-bad-ptr:read-bad-ptr -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'read-bad-ptr' | tests/userprog
+read-boundary | --fs-disk=10 -p tests/userprog/read-boundary:read-boundary -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'read-boundary' | tests/userprog
+read-zero | --fs-disk=10 -p tests/userprog/read-zero:read-zero -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'read-zero' | tests/userprog
+read-stdout | --fs-disk=10 -p tests/userprog/read-stdout:read-stdout --swap-disk=4 | -q   -f run | 'read-stdout' | tests/userprog
+read-bad-fd | --fs-disk=10 -p tests/userprog/read-bad-fd:read-bad-fd --swap-disk=4 | -q   -f run | 'read-bad-fd' | tests/userprog
+write-normal | --fs-disk=10 -p tests/userprog/write-normal:write-normal -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'write-normal' | tests/userprog
+write-bad-ptr | --fs-disk=10 -p tests/userprog/write-bad-ptr:write-bad-ptr -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'write-bad-ptr' | tests/userprog
+write-boundary | --fs-disk=10 -p tests/userprog/write-boundary:write-boundary -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'write-boundary' | tests/userprog
+write-zero | --fs-disk=10 -p tests/userprog/write-zero:write-zero -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'write-zero' | tests/userprog
+write-stdin | --fs-disk=10 -p tests/userprog/write-stdin:write-stdin --swap-disk=4 | -q   -f run | 'write-stdin' | tests/userprog
+write-bad-fd | --fs-disk=10 -p tests/userprog/write-bad-fd:write-bad-fd --swap-disk=4 | -q   -f run | 'write-bad-fd' | tests/userprog
+fork-once | --fs-disk=10 -p tests/userprog/fork-once:fork-once --swap-disk=4 | -q   -f run | 'fork-once' | tests/userprog
+fork-multiple | --fs-disk=10 -p tests/userprog/fork-multiple:fork-multiple --swap-disk=4 | -q   -f run | 'fork-multiple' | tests/userprog
+fork-recursive | --fs-disk=10 -p tests/userprog/fork-recursive:fork-recursive --swap-disk=4 | -q   -f run | 'fork-recursive' | tests/userprog
+fork-read | --fs-disk=10 -p tests/userprog/fork-read:fork-read -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'fork-read' | tests/userprog
+fork-close | --fs-disk=10 -p tests/userprog/fork-close:fork-close -p ../../tests/userprog/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'fork-close' | tests/userprog
+fork-boundary | --fs-disk=10 -p tests/userprog/fork-boundary:fork-boundary --swap-disk=4 | -q   -f run | 'fork-boundary' | tests/userprog
+exec-once | --fs-disk=10 -p tests/userprog/exec-once:exec-once -p tests/userprog/child-simple:child-simple --swap-disk=4 | -q   -f run | 'exec-once' | tests/userprog
+exec-arg | --fs-disk=10 -p tests/userprog/exec-arg:exec-arg -p tests/userprog/child-args:child-args --swap-disk=4 | -q   -f run | 'exec-arg' | tests/userprog
+exec-boundary | --fs-disk=10 -p tests/userprog/exec-boundary:exec-boundary -p tests/userprog/child-simple:child-simple --swap-disk=4 | -q   -f run | 'exec-boundary' | tests/userprog
+exec-missing | --fs-disk=10 -p tests/userprog/exec-missing:exec-missing --swap-disk=4 | -q   -f run | 'exec-missing' | tests/userprog
+exec-bad-ptr | --fs-disk=10 -p tests/userprog/exec-bad-ptr:exec-bad-ptr --swap-disk=4 | -q   -f run | 'exec-bad-ptr' | tests/userprog
+exec-read | --fs-disk=10 -p tests/userprog/exec-read:exec-read -p ../../tests/userprog/sample.txt:sample.txt -p tests/userprog/child-read:child-read --swap-disk=4 | -q   -f run | 'exec-read' | tests/userprog
+wait-simple | --fs-disk=10 -p tests/userprog/wait-simple:wait-simple -p tests/userprog/child-simple:child-simple --swap-disk=4 | -q   -f run | 'wait-simple' | tests/userprog
+wait-twice | --fs-disk=10 -p tests/userprog/wait-twice:wait-twice -p tests/userprog/child-simple:child-simple --swap-disk=4 | -q   -f run | 'wait-twice' | tests/userprog
+wait-killed | --fs-disk=10 -p tests/userprog/wait-killed:wait-killed -p tests/userprog/child-bad:child-bad --swap-disk=4 | -q   -f run | 'wait-killed' | tests/userprog
+wait-bad-pid | --fs-disk=10 -p tests/userprog/wait-bad-pid:wait-bad-pid --swap-disk=4 | -q   -f run | 'wait-bad-pid' | tests/userprog
+multi-recurse | --fs-disk=10 -p tests/userprog/multi-recurse:multi-recurse --swap-disk=4 | -q   -f run | 'multi-recurse 15' | tests/userprog
+multi-child-fd | --fs-disk=10 -p tests/userprog/multi-child-fd:multi-child-fd -p ../../tests/userprog/sample.txt:sample.txt -p tests/userprog/child-close:child-close --swap-disk=4 | -q   -f run | 'multi-child-fd' | tests/userprog
+rox-simple | --fs-disk=10 -p tests/userprog/rox-simple:rox-simple --swap-disk=4 | -q   -f run | 'rox-simple' | tests/userprog
+rox-child | --fs-disk=10 -p tests/userprog/rox-child:rox-child -p tests/userprog/child-rox:child-rox --swap-disk=4 | -q   -f run | 'rox-child' | tests/userprog
+rox-multichild | --fs-disk=10 -p tests/userprog/rox-multichild:rox-multichild -p tests/userprog/child-rox:child-rox --swap-disk=4 | -q   -f run | 'rox-multichild' | tests/userprog
+bad-read | --fs-disk=10 -p tests/userprog/bad-read:bad-read --swap-disk=4 | -q   -f run | 'bad-read' | tests/userprog
+bad-write | --fs-disk=10 -p tests/userprog/bad-write:bad-write --swap-disk=4 | -q   -f run | 'bad-write' | tests/userprog
+bad-read2 | --fs-disk=10 -p tests/userprog/bad-read2:bad-read2 --swap-disk=4 | -q   -f run | 'bad-read2' | tests/userprog
+bad-write2 | --fs-disk=10 -p tests/userprog/bad-write2:bad-write2 --swap-disk=4 | -q   -f run | 'bad-write2' | tests/userprog
+bad-jump | --fs-disk=10 -p tests/userprog/bad-jump:bad-jump --swap-disk=4 | -q   -f run | 'bad-jump' | tests/userprog
+bad-jump2 | --fs-disk=10 -p tests/userprog/bad-jump2:bad-jump2 --swap-disk=4 | -q   -f run | 'bad-jump2' | tests/userprog
+
+[vm]
+pt-grow-stack | --fs-disk=10 -p tests/vm/pt-grow-stack:pt-grow-stack --swap-disk=4 | -q   -f run | 'pt-grow-stack' | tests/vm
+pt-grow-bad | --fs-disk=10 -p tests/vm/pt-grow-bad:pt-grow-bad --swap-disk=4 | -q   -f run | 'pt-grow-bad' | tests/vm
+pt-big-stk-obj | --fs-disk=10 -p tests/vm/pt-big-stk-obj:pt-big-stk-obj --swap-disk=4 | -q   -f run | 'pt-big-stk-obj' | tests/vm
+pt-bad-addr | --fs-disk=10 -p tests/vm/pt-bad-addr:pt-bad-addr --swap-disk=4 | -q   -f run | 'pt-bad-addr' | tests/vm
+pt-bad-read | --fs-disk=10 -p tests/vm/pt-bad-read:pt-bad-read -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'pt-bad-read' | tests/vm
+pt-write-code | --fs-disk=10 -p tests/vm/pt-write-code:pt-write-code --swap-disk=4 | -q   -f run | 'pt-write-code' | tests/vm
+pt-write-code2 | --fs-disk=10 -p tests/vm/pt-write-code2:pt-write-code2 -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'pt-write-code2' | tests/vm
+pt-grow-stk-sc | --fs-disk=10 -p tests/vm/pt-grow-stk-sc:pt-grow-stk-sc --swap-disk=4 | -q   -f run | 'pt-grow-stk-sc' | tests/vm
+page-linear | --fs-disk=10 -p tests/vm/page-linear:page-linear --swap-disk=4 | -q   -f run | 'page-linear' | tests/vm
+page-parallel | --fs-disk=10 -p tests/vm/page-parallel:page-parallel -p tests/vm/child-linear:child-linear --swap-disk=4 | -q   -f run | 'page-parallel' | tests/vm
+page-merge-seq | --fs-disk=10 -p tests/vm/page-merge-seq:page-merge-seq -p tests/vm/child-sort:child-sort --swap-disk=4 | -q   -f run | 'page-merge-seq' | tests/vm
+page-merge-par | --fs-disk=10 -p tests/vm/page-merge-par:page-merge-par -p tests/vm/child-sort:child-sort --swap-disk=10 | -q   -f run | 'page-merge-par' | tests/vm
+page-merge-stk | --fs-disk=10 -p tests/vm/page-merge-stk:page-merge-stk -p tests/vm/child-qsort:child-qsort --swap-disk=10 | -q   -f run | 'page-merge-stk' | tests/vm
+page-merge-mm | --fs-disk=10 -p tests/vm/page-merge-mm:page-merge-mm -p tests/vm/child-qsort-mm:child-qsort-mm --swap-disk=10 | -q   -f run | 'page-merge-mm' | tests/vm
+page-shuffle | --fs-disk=10 -p tests/vm/page-shuffle:page-shuffle --swap-disk=4 | -q   -f run | 'page-shuffle' | tests/vm
+mmap-read | --fs-disk=10 -p tests/vm/mmap-read:mmap-read -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-read' | tests/vm
+mmap-close | --fs-disk=10 -p tests/vm/mmap-close:mmap-close -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-close' | tests/vm
+mmap-unmap | --fs-disk=10 -p tests/vm/mmap-unmap:mmap-unmap -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-unmap' | tests/vm
+mmap-overlap | --fs-disk=10 -p tests/vm/mmap-overlap:mmap-overlap -p tests/vm/zeros:zeros --swap-disk=4 | -q   -f run | 'mmap-overlap' | tests/vm
+mmap-twice | --fs-disk=10 -p tests/vm/mmap-twice:mmap-twice -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-twice' | tests/vm
+mmap-write | --fs-disk=10 -p tests/vm/mmap-write:mmap-write --swap-disk=4 | -q   -f run | 'mmap-write' | tests/vm
+mmap-ro | --fs-disk=10 -p tests/vm/mmap-ro:mmap-ro -p ../../tests/vm/large.txt:large.txt --swap-disk=4 | -q   -f run | 'mmap-ro' | tests/vm
+mmap-exit | --fs-disk=10 -p tests/vm/mmap-exit:mmap-exit -p tests/vm/child-mm-wrt:child-mm-wrt --swap-disk=4 | -q   -f run | 'mmap-exit' | tests/vm
+mmap-shuffle | --fs-disk=10 -p tests/vm/mmap-shuffle:mmap-shuffle --swap-disk=4 | -q   -f run | 'mmap-shuffle' | tests/vm
+mmap-bad-fd | --fs-disk=10 -p tests/vm/mmap-bad-fd:mmap-bad-fd --swap-disk=4 | -q   -f run | 'mmap-bad-fd' | tests/vm
+mmap-clean | --fs-disk=10 -p tests/vm/mmap-clean:mmap-clean -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-clean' | tests/vm
+mmap-inherit | --fs-disk=10 -p tests/vm/mmap-inherit:mmap-inherit -p ../../tests/vm/sample.txt:sample.txt -p tests/vm/child-inherit:child-inherit --swap-disk=4 | -q   -f run | 'mmap-inherit' | tests/vm
+mmap-misalign | --fs-disk=10 -p tests/vm/mmap-misalign:mmap-misalign -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-misalign' | tests/vm
+mmap-null | --fs-disk=10 -p tests/vm/mmap-null:mmap-null -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-null' | tests/vm
+mmap-over-code | --fs-disk=10 -p tests/vm/mmap-over-code:mmap-over-code -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-over-code' | tests/vm
+mmap-over-data | --fs-disk=10 -p tests/vm/mmap-over-data:mmap-over-data -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-over-data' | tests/vm
+mmap-over-stk | --fs-disk=10 -p tests/vm/mmap-over-stk:mmap-over-stk -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-over-stk' | tests/vm
+mmap-remove | --fs-disk=10 -p tests/vm/mmap-remove:mmap-remove -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-remove' | tests/vm
+mmap-zero | --fs-disk=10 -p tests/vm/mmap-zero:mmap-zero --swap-disk=4 | -q   -f run | 'mmap-zero' | tests/vm
+mmap-bad-fd2 | --fs-disk=10 -p tests/vm/mmap-bad-fd2:mmap-bad-fd2 --swap-disk=4 | -q   -f run | 'mmap-bad-fd2' | tests/vm
+mmap-bad-fd3 | --fs-disk=10 -p tests/vm/mmap-bad-fd3:mmap-bad-fd3 --swap-disk=4 | -q   -f run | 'mmap-bad-fd3' | tests/vm
+mmap-zero-len | --fs-disk=10 -p tests/vm/mmap-zero-len:mmap-zero-len --swap-disk=4 | -q   -f run | 'mmap-zero-len' | tests/vm
+mmap-off | --fs-disk=10 -p tests/vm/mmap-off:mmap-off -p ../../tests/vm/large.txt:large.txt --swap-disk=4 | -q   -f run | 'mmap-off' | tests/vm
+mmap-bad-off | --fs-disk=10 -p tests/vm/mmap-bad-off:mmap-bad-off -p ../../tests/vm/large.txt:large.txt --swap-disk=4 | -q   -f run | 'mmap-bad-off' | tests/vm
+mmap-kernel | --fs-disk=10 -p tests/vm/mmap-kernel:mmap-kernel -p ../../tests/vm/sample.txt:sample.txt --swap-disk=4 | -q   -f run | 'mmap-kernel' | tests/vm
+lazy-file | --fs-disk=10 -p tests/vm/lazy-file:lazy-file -p ../../tests/vm/sample.txt:sample.txt -p ../../tests/vm/small.txt:small.txt --swap-disk=4 | -q   -f run | 'lazy-file' | tests/vm
+lazy-anon | --fs-disk=10 -p tests/vm/lazy-anon:lazy-anon --swap-disk=4 | -q   -f run | 'lazy-anon' | tests/vm
+swap-file | --fs-disk=10 -p tests/vm/swap-file:swap-file -p ../../tests/vm/large.txt:large.txt --swap-disk=10 | -q   -f run | 'swap-file' | tests/vm
+swap-anon | --fs-disk=10 -p tests/vm/swap-anon:swap-anon --swap-disk=30 | -q   -f run | 'swap-anon' | tests/vm
+swap-iter | --fs-disk=10 -p tests/vm/swap-iter:swap-iter -p ../../tests/vm/large.txt:large.txt --swap-disk=50 | -q   -f run | 'swap-iter' | tests/vm
+swap-fork | --fs-disk=10 -p tests/vm/swap-fork:swap-fork -p tests/vm/child-swap:child-swap --swap-disk=200 | -q   -f run | 'swap-fork' | tests/vm
+
+[filesys/base]
+lg-create | --fs-disk=10 -p tests/filesys/base/lg-create:lg-create --swap-disk=4 | -q   -f run | 'lg-create' | tests/filesys/base
+lg-full | --fs-disk=10 -p tests/filesys/base/lg-full:lg-full --swap-disk=4 | -q   -f run | 'lg-full' | tests/filesys/base
+lg-random | --fs-disk=10 -p tests/filesys/base/lg-random:lg-random --swap-disk=4 | -q   -f run | 'lg-random' | tests/filesys/base
+lg-seq-block | --fs-disk=10 -p tests/filesys/base/lg-seq-block:lg-seq-block --swap-disk=4 | -q   -f run | 'lg-seq-block' | tests/filesys/base
+lg-seq-random | --fs-disk=10 -p tests/filesys/base/lg-seq-random:lg-seq-random --swap-disk=4 | -q   -f run | 'lg-seq-random' | tests/filesys/base
+sm-create | --fs-disk=10 -p tests/filesys/base/sm-create:sm-create --swap-disk=4 | -q   -f run | 'sm-create' | tests/filesys/base
+sm-full | --fs-disk=10 -p tests/filesys/base/sm-full:sm-full --swap-disk=4 | -q   -f run | 'sm-full' | tests/filesys/base
+sm-random | --fs-disk=10 -p tests/filesys/base/sm-random:sm-random --swap-disk=4 | -q   -f run | 'sm-random' | tests/filesys/base
+sm-seq-block | --fs-disk=10 -p tests/filesys/base/sm-seq-block:sm-seq-block --swap-disk=4 | -q   -f run | 'sm-seq-block' | tests/filesys/base
+sm-seq-random | --fs-disk=10 -p tests/filesys/base/sm-seq-random:sm-seq-random --swap-disk=4 | -q   -f run | 'sm-seq-random' | tests/filesys/base
+syn-read | --fs-disk=10 -p tests/filesys/base/syn-read:syn-read -p tests/filesys/base/child-syn-read:child-syn-read --swap-disk=4 | -q   -f run | 'syn-read' | tests/filesys/base
+syn-remove | --fs-disk=10 -p tests/filesys/base/syn-remove:syn-remove --swap-disk=4 | -q   -f run | 'syn-remove' | tests/filesys/base
+syn-write | --fs-disk=10 -p tests/filesys/base/syn-write:syn-write -p tests/filesys/base/child-syn-wrt:child-syn-wrt --swap-disk=4 | -q   -f run | 'syn-write' | tests/filesys/base
+
+[threads]
+alarm-single | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'alarm-single' | tests/threads
+alarm-multiple | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'alarm-multiple' | tests/threads
+alarm-simultaneous | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'alarm-simultaneous' | tests/threads
+alarm-priority | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'alarm-priority' | tests/threads
+alarm-zero | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'alarm-zero' | tests/threads
+alarm-negative | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'alarm-negative' | tests/threads
+priority-change | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-change' | tests/threads
+priority-donate-one | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-one' | tests/threads
+priority-donate-multiple | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-multiple' | tests/threads
+priority-donate-multiple2 | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-multiple2' | tests/threads
+priority-donate-nest | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-nest' | tests/threads
+priority-donate-sema | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-sema' | tests/threads
+priority-donate-lower | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-lower' | tests/threads
+priority-fifo | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-fifo' | tests/threads
+priority-preempt | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-preempt' | tests/threads
+priority-sema | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-sema' | tests/threads
+priority-condvar | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-condvar' | tests/threads
+priority-donate-chain | --fs-disk=10 --swap-disk=4 | -q  -threads-tests -f run | 'priority-donate-chain' | tests/threads
+
+[vm/cow]
+cow-simple | --fs-disk=10 -p tests/vm/cow/cow-simple:cow-simple --swap-disk=4 | -q   -f run | 'cow-simple' | tests/vm/cow
+
+# Total testcases: 141
+# Generated on 2025-08-05

--- a/vm/.test_status
+++ b/vm/.test_status
@@ -1,0 +1,1 @@
+alarm-single FAIL

--- a/vm/select_test.sh
+++ b/vm/select_test.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+
+# Usage: select_test.sh [-q|-g] [-r]
+#   -q|-g : 실행 모드 지정
+#   -r    : clean & rebuild
+if (( $# < 1 || $# > 2 )); then
+  echo "Usage: $0 [-q|-g] [-r]"
+  echo "  -q   : run tests quietly (no GDB stub)"
+  echo "  -g   : attach via GDB stub (skip build)"
+  echo "  -r   : force clean & full rebuild"
+  exit 1
+fi
+
+MODE="$1"
+if [[ "$MODE" != "-q" && "$MODE" != "-g" ]]; then
+  echo "Usage: $0 [-q|-g] [-r]"
+  exit 1
+fi
+
+# 두 번째 인자가 있으면 -r 체크
+REBUILD=0
+if (( $# == 2 )); then
+  if [[ "$2" == "-r" ]]; then
+    REBUILD=1
+  else
+    echo "Unknown option: $2"
+    echo "Usage: $0 [-q|-g] [-r]"
+    exit 1
+  fi
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../activate"
+
+CONFIG_FILE="${SCRIPT_DIR}/.test_config"
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Error: .test_config 파일이 없습니다: ${CONFIG_FILE}" >&2
+  exit 1
+fi
+
+declare -A config_pre_args    
+declare -A config_post_args   
+declare -A config_prog_args   
+declare -A config_result      
+declare -A GROUP_TESTS TEST_GROUP MENU_TESTS
+declare -a ORDERED_GROUPS
+tests=()
+
+current_group=""
+
+while IFS= read -r raw; do
+  line="${raw%%\#*}"
+  line="$(echo "$line" | xargs)"
+  [[ -z "$line" ]] && continue
+
+  if [[ "$line" =~ ^\[(.+)\]$ ]]; then
+    current_group="${BASH_REMATCH[1]}"
+    ORDERED_GROUPS+=("$current_group")
+    GROUP_TESTS["$current_group"]=""
+  else
+    IFS='|' read -r test pre_args post_args prog_args test_path <<< "$line"
+    test="$(echo "$test"       | xargs)"
+    pre_args="$(echo "$pre_args"   | xargs)"
+    post_args="$(echo "$post_args" | xargs)"
+    prog_args="$(echo "$prog_args" | xargs)"
+    test_path="$(echo "$test_path" | xargs)"
+
+    config_pre_args["$test"]="$pre_args"
+    config_post_args["$test"]="$post_args"
+    config_prog_args["$test"]="$prog_args"
+    config_result["$test"]="$test_path"
+    tests+=("$test")
+
+    TEST_GROUP["$test"]="$current_group"
+    GROUP_TESTS["$current_group"]+="$test "
+  fi
+done < "$CONFIG_FILE"
+
+for test in "${tests[@]}"; do
+  grp="${config_result[$test]}"
+  GROUP_TESTS["$grp"]+="$test "
+done
+
+if [[ ! -d "${SCRIPT_DIR}/build" ]]; then
+  echo "Build directory not found. Building Pintos vm..."
+  make -C "${SCRIPT_DIR}" clean all
+fi
+
+if (( REBUILD )); then
+  echo "Force rebuilding Pintos vm..."
+  make -C "${SCRIPT_DIR}" clean all
+fi
+
+STATE_FILE="${SCRIPT_DIR}/.test_status"
+declare -A status_map
+
+if [[ -f "$STATE_FILE" ]]; then
+  while read -r test stat; do
+    status_map["$test"]="$stat"
+  done < "$STATE_FILE"
+fi
+
+echo "=== Available Pintos Tests ==="
+index=1
+for grp in "${ORDERED_GROUPS[@]}"; do
+  tests_in_grp="${GROUP_TESTS[$grp]}"
+  [[ -z "$tests_in_grp" ]] && continue
+
+  echo
+  echo "▶ ${grp^} tests:"
+  for test in $tests_in_grp; do
+    stat="${status_map[$test]:-untested}"
+    case "$stat" in
+      PASS) color="\e[32m" ;;
+      FAIL) color="\e[31m" ;;
+      *)    color="\e[0m"  ;;
+    esac
+    printf "  ${color}%2d) %s\e[0m\n" "$index" "$test"
+    MENU_TESTS[$index]="$test"
+    ((index++))
+  done
+done
+
+read -p "Enter test numbers (e.g. '1 3 5' or '2-4'): " input
+tokens=()
+for tok in ${input//,/ }; do
+  if [[ "$tok" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+    for ((n=${BASH_REMATCH[1]}; n<=${BASH_REMATCH[2]}; n++)); do
+      tokens+=("$n")
+    done
+  else
+    tokens+=("$tok")
+  fi
+done
+
+declare -A seen=()
+sel_tests=()
+for n in "${tokens[@]}"; do
+  if [[ "$n" =~ ^[0-9]+$ ]] && (( n>=1 && n<=${#tests[@]} )); then
+    idx=$((n-1))
+    if [[ -z "${seen[$n]}" ]]; then
+      sel_tests+=("${MENU_TESTS[$n]}")
+      seen[$n]=1
+    fi
+  else
+    echo "Invalid test number: $n" >&2
+    exit 1
+  fi
+done
+
+echo "Selected tests: ${sel_tests[*]}"
+
+passed=()
+failed=()
+{
+  cd "${SCRIPT_DIR}/build" || exit 1
+
+  count=0
+  total=${#sel_tests[@]}
+  for test in "${sel_tests[@]}"; do
+    echo
+    pre_args="${config_pre_args[$test]}"
+    post_args="${config_post_args[$test]}"
+    prog_args="${config_prog_args[$test]}"
+    dir="${config_result[$test]}"
+    res="${dir}/${test}.result"
+
+    mkdir -p ${dir}
+    
+    if [[ "$MODE" == "-q" ]]; then
+      cmd="pintos ${pre_args} -- ${post_args} '${prog_args}'"
+      echo "Running ${test} in batch mode... "
+      echo "\$ ${cmd}"
+      echo
+      if make -s ${res} \
+            ARGS="${pre_args} -- ${post_args} '${prog_args}'"; then
+        if grep -q '^PASS' ${res}; then
+          echo "PASS"; passed+=("$test")
+        else
+          echo "FAIL"; failed+=("$test")
+        fi
+      else
+        echo "FAIL"; failed+=("$test")
+      fi
+    else
+      echo -e "=== Debugging \e[33m${test}\e[0m ($(( count + 1 ))/${total}) ==="
+      echo -e "\e[33mVSCode의 \"Pintos Debug\" 디버그를 시작하세요.\e[0m"
+      echo " * QEMU 창이 뜨고, gdb stub은 localhost:1234 에서 대기합니다."
+      echo " * 내부 출력은 터미널에 보이면서 '${dir}/${test}.output'에도 저장됩니다."
+      echo
+
+      cmd="pintos --gdb ${pre_args} -- ${post_args} '${prog_args}'"
+      echo "\$ ${cmd}"
+      eval "${cmd}" 2>&1 | tee "${dir}/${test}.output"
+
+      repo_root="${SCRIPT_DIR}/.."
+      ck="${repo_root}/${dir}/${test}.ck"
+      if [[ -f "$ck" ]]; then
+        perl -I "${repo_root}" \
+             "$ck" "${dir}/${test}" "${dir}/${test}.result"
+        if grep -q '^PASS' "${dir}/${test}.result"; then
+          echo "=> PASS"; passed+=("$test")
+        else
+          echo "=> FAIL"; failed+=("$test")
+        fi
+      else
+        echo "=> No .ck script, skipping result."; failed+=("$test")
+      fi
+      echo "=== ${test} session end ==="
+    fi
+
+    ((count++))
+    echo -e "\e[33mtest ${count}/${total} finish\e[0m"
+  done
+}
+
+echo
+echo "=== Test Summary ==="
+echo "Passed: ${#passed[@]}"
+for t in "${passed[@]}"; do echo "  - $t"; done
+echo "Failed: ${#failed[@]}"
+for t in "${failed[@]}"; do echo "  - $t"; done
+
+for t in "${passed[@]}"; do
+  status_map["$t"]="PASS"
+done
+for t in "${failed[@]}"; do
+  status_map["$t"]="FAIL"
+done
+
+> "$STATE_FILE"
+for test in "${!status_map[@]}"; do
+  echo "$test ${status_map[$test]}"
+done >| "$STATE_FILE"


### PR DESCRIPTION
**변경 배경(Motivation)**

* `vm/` 모듈이 올바르게 빌드되지 않는 문제를 해결하고자 합니다.
* `enum vm_type` 정의가 여러 헤더 파일에 분산되어 있어 인클루드 순서 의존성이 발생했습니다.
* `.test_status` 파일의 테스트 PASS/FAIL 상태가 변경되어 일부 테스트가 의도치 않게 실패하거나 순서가 꼬이는 현상이 있었습니다.
* `process_impl.c` 내 VM 분기 처리가 누락되어, VM 미사용 환경에서 스택 푸시 시 빌드 에러가 발생했습니다.

**변경 내용(Summary)**

1. **`vm_type.h` 파일 추가**

   * `enum vm_type` 정의를 `vm/vm_type.h`로 분리하여 순환참조를 해소했습니다.

2. **헤더 인클루드 수정**

   * `vm/uninit.h`에서 `"vm/vm.h"` 대신 `<stdbool.h>` 및 `"vm/vm_type.h"`를 인클루드하도록 변경했습니다.
   * `vm/vm.h`에서 `enum vm_type` 정의를 포함했던 부분을 제거하고, 대신 `"vm/vm_type.h"`를 먼저 인클루드하도록 수정했습니다.
   * 헤더 파일 간 순환 참조를 방지하기 위해 `uninit.h`, `anon.h`, `file.h` 등의 의존성을 정리했습니다.


3. **`process_impl.c` 수정**

   * `push_stack` 함수 내 VM 사용 시에도 빌드가 가능하도록 `#ifndef VM` 분기 구문을 추가했습니다.

**동작 검증(Testing)**

* `make`, `make check` 모두 VM 활성화/비활성화 빌드에서 빌드 가능함을 확인했습니다.

